### PR TITLE
Fix JSON validity in Delphinus.Install.json

### DIFF
--- a/Delphinus.Install.json
+++ b/Delphinus.Install.json
@@ -31,7 +31,7 @@
 		{
 			"project": "packages\\WebView4Delphi_group.groupproj",
       "compiler_min": 24,
-      "compiler_max": 24,      
+      "compiler_max": 24
 		}
 	],
 


### PR DESCRIPTION
I noticed Delphinus refuses to install WebView4Delphi, it (correctly) says that `Delphinus.Install.json` is not a valid JSON.

This trivial PR fixes it by removing an excessive comma.

( FYI @Memnarch , author of Delphinus. )